### PR TITLE
Update linter.yml

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup smalltalkCI
         uses: hpi-swa/setup-smalltalkCI@v1
         with:
-          smalltalk-version: Squeak64-5.3
+          smalltalk-image: Squeak64-5.3
       - name: Test MorphicAPIExplorer
         run: smalltalkci -s Squeak64-5.3 .linter.ston
         shell: bash


### PR DESCRIPTION
'smalltalk-version' is deprecated and may stop orking in the future. 'smalltalk-image' is the new syntax according to the warning after a linter run